### PR TITLE
Encapsulate random

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -13,9 +13,8 @@
 
 
 RayTracerApplication::RayTracerApplication()
-    : rayTracer(scene, camera)
+    : randomGenerator(std::make_shared<RandomGenerator>(RandomGenerator())), rayTracer(scene, camera, randomGenerator)
 {
-    randomGenerator = std::make_shared<RandomGenerator>(RandomGenerator());
     initializeScene();
     initializeCamera();
     initializeRayTracer();

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -3,7 +3,6 @@
 
 #include <chrono>
 #include <iostream>
-#include <random>
 
 #include "camera.hpp"
 #include "scene.hpp"
@@ -16,6 +15,7 @@
 RayTracerApplication::RayTracerApplication()
     : rayTracer(scene, camera)
 {
+    randomGenerator = std::make_shared<RandomGenerator>(RandomGenerator());
     initializeScene();
     initializeCamera();
     initializeRayTracer();
@@ -138,7 +138,8 @@ void RayTracerApplication::initializeCamera()
         Vec3(-17.0, 7.0, 10.0),
         Orientation( M_PI * 0.0, M_PI * -0.11, M_PI * 0.125),
         terminalWidth, terminalHeight,
-        45.0 * M_PI / 180.0, terminalCharHeight
+        45.0 * M_PI / 180.0, terminalCharHeight,
+        randomGenerator
     );
 }
 

--- a/src/application.hpp
+++ b/src/application.hpp
@@ -2,8 +2,11 @@
 #define _RAYTRACERAPPLICATION_
 
 
-#include "camera.hpp"
+#include <memory>
+
+#include "randomgenerator.hpp"
 #include "scene.hpp"
+#include "camera.hpp"
 #include "raytracer.hpp"
 
 
@@ -18,6 +21,7 @@ public:
     void run();
 
 private:
+    std::shared_ptr<RandomGenerator> randomGenerator;
     Scene scene;
     Camera camera;
     RayTracer rayTracer;

--- a/src/randomgenerator.cpp
+++ b/src/randomgenerator.cpp
@@ -1,0 +1,33 @@
+#include "randomgenerator.hpp"
+
+
+#include <random>
+
+#include "raymath/constants.hpp"
+
+
+RandomGenerator::RandomGenerator()
+{
+    std::random_device randomDevice;
+    randomEngine.seed(randomDevice());
+
+    unitDistribution = std::uniform_real_distribution<double>(0.0, 1.0);
+    trigDistribution = std::uniform_real_distribution<double>(-1.0, 1.0);
+    angleDistribution = std::uniform_real_distribution<double>(-pi, pi);
+}
+RandomGenerator::~RandomGenerator()
+{
+}
+
+double RandomGenerator::randomLinearUnit()
+{
+    return unitDistribution(randomEngine);
+}
+double RandomGenerator::randomLinearTrig()
+{
+    return trigDistribution(randomEngine);
+}
+double RandomGenerator::randomLinearAngle()
+{
+    return angleDistribution(randomEngine);
+}

--- a/src/randomgenerator.hpp
+++ b/src/randomgenerator.hpp
@@ -1,0 +1,26 @@
+#ifndef _RAYTRACERRANDOMGENERATOR_
+#define _RAYTRACERRANDOMGENERATOR_
+
+
+#include <random>
+
+
+class RandomGenerator
+{
+public:
+    RandomGenerator();
+    ~RandomGenerator();
+
+    double randomLinearUnit();
+    double randomLinearTrig();
+    double randomLinearAngle();
+
+private:
+    std::mt19937 randomEngine;
+    std::uniform_real_distribution<double> unitDistribution;
+    std::uniform_real_distribution<double> trigDistribution;
+    std::uniform_real_distribution<double> angleDistribution;
+};
+
+
+#endif

--- a/src/raytracer.hpp
+++ b/src/raytracer.hpp
@@ -3,6 +3,7 @@
 
 
 #include <random>
+#include <memory>
 
 #include "frame.hpp"
 #include "scene.hpp"
@@ -17,7 +18,7 @@ Wrapper class for ray bouncing, sample generation and ray-traced rendering.
 class RayTracer
 {
 public:
-    RayTracer(Scene& initScene, Camera& initCamera);
+    RayTracer(Scene& initScene, Camera& initCamera, const std::shared_ptr<RandomGenerator>& prandomGenerator);
 
     // Run whenever anything about camera changed, or the camera changes completely.
     void setCamera(Camera& newCamera);
@@ -32,21 +33,21 @@ public:
 
     // Sample incoming light from given ray's direction to its origin.
     // Will terminate path if depthLeft reaches 0.
-    Vec3<double> traceRay(Ray ray, unsigned int depthLeft);
+    Vec3<double> traceRay(Ray ray, unsigned int depthLeft) const;
 
     // Generate outgoing ray direction based on incoming ray, surface normal and material properties.
-    Vec3<double> bounceDirection(const Vec3<double>& incomingRay, const Vec3<double>& normal, bool isSpecularBounce, double materialSmoothness);
+    Vec3<double> bounceDirection(const Vec3<double>& incomingRay, const Vec3<double>& normal, bool isSpecularBounce, double materialSmoothness) const;
 
     const unsigned int& getSampleCount() const;
     const unsigned int& getMaxSamples() const;
 
     const Frame& getFrame() const;
 
-    Vec3<double> getRandomUniformDirectionSphere();
-    Vec3<double> getRandomUniformDirectionHemisphere(const Vec3<double>& normal);
+    Vec3<double> getRandomUniformDirectionSphere() const;
+    Vec3<double> getRandomUniformDirectionHemisphere(const Vec3<double>& normal) const;
     // Cosine-biased hemisphere distribution.
     // This means low-angle diffuse reflections don't need scaled down, instead they are just sampled less.
-    Vec3<double> getRandomBiasedDirectionHemisphere(const Vec3<double>& normal);
+    Vec3<double> getRandomBiasedDirectionHemisphere(const Vec3<double>& normal) const;
 
 private:
     unsigned int sampleCount, maxSamples, maxBounces;
@@ -56,10 +57,7 @@ private:
 
     Scene& scene;
 
-    std::mt19937 randomEngine;
-    std::uniform_real_distribution<double> unitDistribution;
-    std::uniform_real_distribution<double> trigDistribution;
-    std::uniform_real_distribution<double> angleDistribution;
+    std::shared_ptr<RandomGenerator> randomGenerator;
 };
 
 


### PR DESCRIPTION
Move all random generation into its own component, so that other components don't need to keep track of their own random engine's state. This allows many methods to be const that previously couldn't.

Closes #16 